### PR TITLE
Gracefully handle email errors in auth flows

### DIFF
--- a/Backend/Controllers/auth.controller.js
+++ b/Backend/Controllers/auth.controller.js
@@ -98,8 +98,11 @@ export const verifyEmail = async (req, res) => {
     user.verificationToken = undefined;
     user.verificationTokenExpiresAt = undefined;
     await user.save();
-
-    await sendWelcomeEmail(user.email, user.name);
+    try {
+      await sendWelcomeEmail(user.email, user.name);
+    } catch (emailError) {
+      console.error("Welcome email error:", emailError.message);
+    }
 
     return res.status(200).json({
       success: true,
@@ -252,7 +255,14 @@ export const forgetPassword = async (req, res) => {
     await user.save();
 
     const resetUrl = `${process.env.CLIENT_URL}/reset-password/${resetToken}`;
-    await sendPasswordResetEmail(user.email, resetUrl);
+    try {
+      await sendPasswordResetEmail(user.email, resetUrl);
+    } catch (emailError) {
+      console.error(
+        "Password reset email error:",
+        emailError.message
+      );
+    }
 
     return res.status(200).json({
       success: true,
@@ -313,7 +323,14 @@ export const ResetPassword = async (req, res) => {
     userToUpdate.resetPasswordExpiresAt = undefined;
 
     await userToUpdate.save();
-    await sendResetSuccessEmail(userToUpdate.email, userToUpdate.name);
+    try {
+      await sendResetSuccessEmail(userToUpdate.email, userToUpdate.name);
+    } catch (emailError) {
+      console.error(
+        "Reset success email error:",
+        emailError.message
+      );
+    }
 
     return res
       .status(200)

--- a/Backend/Mails/emails.js
+++ b/Backend/Mails/emails.js
@@ -46,18 +46,22 @@ export const sendWelcomeEmail = async (email, name="User") => {
     "../../frontend/public/assets/logo.png"
   );
 
+  const attachments = fs.existsSync(logoPath)
+    ? [
+        {
+          filename: "logo.png",
+          path: logoPath,
+          cid: "logo", // Content ID referenced in the HTML
+        },
+      ]
+    : [];
+
   const mailOptions = {
     from: `"InsightSphere" <${process.env.GMAIL_USER} >`,
     to: email,
     subject: "Welcome to InsightSphere",
     html: WELCOME_EMAIL_TEMPLATE(name),
-    attachments: [
-      {
-        filename: "logo.png",
-        path: logoPath,
-        cid: "logo", // Content ID referenced in the HTML
-      },
-    ],
+    attachments,
   };
 
   try {
@@ -76,19 +80,23 @@ export const sendPasswordResetEmail = async (email, resetLink) => {
     __dirname,
     "../../frontend/public/assets/logo.png"
   );
-  
+
+  const attachments = fs.existsSync(logoPath)
+    ? [
+        {
+          filename: "logo.png",
+          path: logoPath,
+          cid: "logo", // Content ID referenced in the HTML
+        },
+      ]
+    : [];
+
   const mailOptions = {
     from: `"InsightSphere" <${process.env.GMAIL_USER} >`,
     to: email,
     subject: "Password Reset Request",
     html: PASSWORD_RESET_REQUEST_TEMPLATE(resetLink),
-    attachments: [
-      {
-        filename: "logo.png",
-        path: logoPath,
-        cid: "logo", // Content ID referenced in the HTML
-      },
-    ],
+    attachments,
   }
 
   try {
@@ -106,18 +114,22 @@ export const sendResetSuccessEmail = async (email, name= "User") => {
     __dirname,
     "../../frontend/public/assets/logo.png"
   );
+  const attachments = fs.existsSync(logoPath)
+    ? [
+        {
+          filename: "logo.png",
+          path: logoPath,
+          cid: "logo", // Content ID referenced in the HTML
+        },
+      ]
+    : [];
+
   const mailOptions = {
     from: `"InsightSphere" <${process.env.GMAIL_USER} >`,
     to: email,
     subject: "Password Reset Success",
     html: PASSWORD_RESET_SUCCESS_TEMPLATE(name),
-    attachments: [
-      {
-        filename: "logo.png",
-        path: logoPath,
-        cid: "logo", // Content ID referenced in the HTML
-      },
-    ],
+    attachments,
   }
 
   try {


### PR DESCRIPTION
## Summary
- Avoid failing verification and password reset when email sending fails
- Include logo attachments only if file exists to prevent missing file errors
- Log but do not surface welcome/reset email failures to users

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af2a95bd44832eb0f06cf5341e3615